### PR TITLE
Ignore Error when  Ansible Galaxy unreachable

### DIFF
--- a/files/ansible/avi-controller-aws-all-in-one-play.yml.tpl
+++ b/files/ansible/avi-controller-aws-all-in-one-play.yml.tpl
@@ -572,6 +572,7 @@
           shell: patch --directory /opt/avi/python/bin/portal/api/ < /home/admin/ansible/views_albservices.patch
 %{ endif ~}
       tags: register_controller
+      ignore_errors: true
 
     - name: Remove patch file
       ansible.builtin.file:


### PR DESCRIPTION
Meets requirements for instances where access to Ansible Galaxy may not be permitted.
Fixes #21 