### PR TITLE
Fix for missing AMI from Marketplace

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -9,6 +9,7 @@ data "aws_subnet" "custom" {
   id       = each.value
 }
 data "aws_ami" "avi" {
+  count       = var.custom_ami == null ? 1 : 0
   most_recent = true
   owners      = ["aws-marketplace"]
 

--- a/ec2-avi.tf
+++ b/ec2-avi.tf
@@ -68,7 +68,7 @@ locals {
 
 resource "aws_instance" "avi_controller" {
   count = var.controller_ha ? 3 : 1
-  ami   = var.custom_ami == null ? data.aws_ami.avi.id : var.custom_ami
+  ami   = var.custom_ami == null ? data.aws_ami.avi[count.index].id : var.custom_ami
   root_block_device {
     volume_size           = var.boot_disk_size
     delete_on_termination = true


### PR DESCRIPTION
When there is no AMI int he Marketplace that matches the specified version, the data lookup was failing.

When using a custom_ami with a version that isn't available in the Marketplace, it does not proceed due to the error.

Fix will not run the data lookup if a custom_ami is defined.